### PR TITLE
fix(form): evitado que formulários ocultos bloqueie o envio

### DIFF
--- a/front-end/pages/professor/criar-ordem.html
+++ b/front-end/pages/professor/criar-ordem.html
@@ -120,7 +120,7 @@
                 <div id="classroom-fields" class="location-fields">
                     <div class="form-group">
                         <label for="classroom">Sala*</label>
-                        <select id="classroom" name="classroom" required>
+                        <select id="classroom" name="classroom" >
                             <option value="">Selecione a sala...</option>
                             <optgroup label="Bloco 3 - Térreo">
                                 <option value="101">101</option>
@@ -212,7 +212,7 @@
                 
                 <div class="form-group">
                     <label for="equipment-type">Equipamento*</label>
-                    <select id="equipment-type" name="equipment-type" required>
+                    <select id="equipment-type" name="equipment-type">
                         <option value="">Selecione o equipamento...</option>
                         <!-- Preenchido dinamicamente via JS -->
                     </select>
@@ -220,7 +220,7 @@
 
                 <div class="form-group">
                     <label for="problem-type">Tipo de Problema*</label>
-                    <select id="problem-type" name="problem-type" required>
+                    <select id="problem-type" name="problem-type" >
                         <option value="">Selecione o tipo de problema...</option>
                         <!-- Preenchido dinamicamente via JS -->
                     </select>
@@ -228,7 +228,7 @@
 
                 <div class="form-group">
                     <label for="problem-description">Descrição Detalhada*</label>
-                    <textarea id="problem-description" name="problem-description" rows="4" required placeholder="Descreva o problema com detalhes..."></textarea>
+                    <textarea id="problem-description" name="problem-description" rows="4" placeholder="Descreva o problema com detalhes..."></textarea>
                 </div>
             </div>
 


### PR DESCRIPTION
O problema estava no HTML.

O formulário de relatar problemas tinha atributos de **required**, enquanto o de solicitação não tinha nenhum.

Com isso, enviar o forms de problemas ia normalmente, enquanto o de solicitação era bloqueado pelo navegador.